### PR TITLE
add ~pandux to oracle list

### DIFF
--- a/desk/bare/web/fund/page/proj-edit.hoon
+++ b/desk/bare/web/fund/page/proj-edit.hoon
@@ -202,7 +202,7 @@
                     =+  dad=(sein:title our.bol now.bol our.bol)
                     ::  FIXME: These options are hard-coded from the
                     ::  ~tocwex.syndicate group's oracle directory
-                    %+  turn  ~[!<(@p (slot:config %point)) dad ~reb ~bitdeg ~roswet ~nisfeb ~hosdys ~ridlyd ~darlur ~mocbel ~posdeg ~dalten]
+                    %+  turn  ~[!<(@p (slot:config %point)) dad ~reb ~bitdeg ~dalten ~darlur ~hosdys ~mocbel ~nisfeb ~pandux ~posdeg ~ridlyd ~roswet]
                     |=  ora=@p
                     ^-  manx
                     :_  ; {<ora>}


### PR DESCRIPTION
@sidnym-ladrut, got this last minute request from `~midlev-mindyr` to have ~pandux in the list; can we get this into 1.3?

reordered the list to be alphabetical after galaxies, as well.